### PR TITLE
Remove special handling of default implementations in Task

### DIFF
--- a/src/main/java/org/embulk/util/config/TaskField.java
+++ b/src/main/java/org/embulk/util/config/TaskField.java
@@ -63,9 +63,6 @@ final class TaskField {
         if (getterMethod.getParameterTypes().length != 0) {
             return null;
         }
-        if (getterMethod.isDefault() && getterMethod.getAnnotation(Config.class) == null) {
-            return null;
-        }
 
         final Optional<String> name = Tasks.getFieldNameFromGetter(getterMethod.getName());
         if (!name.isPresent()) {


### PR DESCRIPTION
The special handling has been introduced since embulk-core v0.9.0 in:
https://github.com/embulk/embulk/pull/889

Its goal was to deprecate Joda-Time's DateTimeZone used in some of embulk-core's predefined Task, with compatibilities kept.

The embulk-util-config library is totally for plugins, on the other hand. Everything should be on plugin's side, and each plugin does not need to consider compatibility just in itself.

This part is unnecessarily complicating the implementation. It's time to remove it.