### PR TITLE
Capture violation details in TaskValidationException

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -35,6 +35,7 @@ dependencies {
     implementation "com.fasterxml.jackson.datatype:jackson-datatype-jdk8:2.6.7"  // Required for java.util.Optional.
 
     testImplementation "org.embulk:embulk-api:0.10.2"
+    testImplementation "org.apache.bval:bval-jsr303:0.5"
     testImplementation "org.junit.jupiter:junit-jupiter-api:5.6.1"
     testRuntimeOnly "org.junit.jupiter:junit-jupiter-engine:5.6.1"
 

--- a/src/main/java/org/embulk/util/config/ConfigMapperFactory.java
+++ b/src/main/java/org/embulk/util/config/ConfigMapperFactory.java
@@ -157,7 +157,7 @@ public final class ConfigMapperFactory {
         objectMapper.registerModule(new TaskDeserializerModule(objectMapper, this.validator));  // Difference from ConfigMapper.
         objectMapper.registerModule(new DataSourceModule(objectMapper));
 
-        return new TaskMapper(objectMapper);
+        return new TaskMapper(objectMapper, this.validator);
     }
 
     private final List<Module> additionalModules;

--- a/src/main/java/org/embulk/util/config/TaskValidationException.java
+++ b/src/main/java/org/embulk/util/config/TaskValidationException.java
@@ -26,7 +26,21 @@ import org.embulk.config.ConfigException;
  */
 public class TaskValidationException extends ConfigException {
     <T> TaskValidationException(final Set<ConstraintViolation<T>> violations) {
-        super("Configuration violates constraints validated in task definition.",
-              new ConstraintViolationException(violations));
+        super(formatMessage(violations), new ConstraintViolationException(violations));
+    }
+
+    private static <T> String formatMessage(Set<ConstraintViolation<T>> violations) {
+        StringBuilder sb = new StringBuilder();
+        sb.append("Configuration violates constraints validated in task definition.");
+        for (ConstraintViolation<?> violation : violations) {
+            sb.append(" '");
+            sb.append(violation.getPropertyPath());
+            sb.append("' ");
+            sb.append(violation.getMessage());
+            sb.append(" but got ");
+            sb.append(violation.getInvalidValue());
+            sb.append('.');
+        }
+        return sb.toString();
     }
 }


### PR DESCRIPTION
This PR does two things:
- Enabled validation in TaskMapper, as I see it is both technically and practically legit to modify the TaskObject/TaskSource (potentially making them invalid) before handover it to the task workers.
- Retained the old behavior from `org.embulk.config.TaskValidationException` that it encaptures the violation details in its message. There's a slight modification over the format: single quotes around the property name and violation messages are separated by periods.