### PR TITLE
Capture violation details in TaskValidationException

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -35,6 +35,7 @@ dependencies {
     implementation "com.fasterxml.jackson.datatype:jackson-datatype-jdk8:2.6.7"  // Required for java.util.Optional.
 
     testImplementation "org.embulk:embulk-api:0.10.2"
+    testImplementation "org.apache.bval:bval-jsr303:0.5"
     testImplementation "org.junit.jupiter:junit-jupiter-api:5.6.1"
     testRuntimeOnly "org.junit.jupiter:junit-jupiter-engine:5.6.1"
 

--- a/src/legacyTest/java/org/embulk/util/config/legacy/TestConfigMapper.java
+++ b/src/legacyTest/java/org/embulk/util/config/legacy/TestConfigMapper.java
@@ -19,8 +19,13 @@ package org.embulk.util.config.legacy;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 
 import java.util.Optional;
+import javax.validation.Validation;
+import javax.validation.constraints.Max;
+
+import org.apache.bval.jsr303.ApacheValidationProvider;
 import org.embulk.EmbulkTestRuntime;
 import org.embulk.util.config.Config;
 import org.embulk.util.config.ConfigDefault;
@@ -28,6 +33,7 @@ import org.embulk.util.config.ConfigMapper;
 import org.embulk.util.config.ConfigMapperFactory;
 import org.embulk.util.config.Task;
 import org.embulk.util.config.TaskMapper;
+import org.embulk.util.config.TaskValidationException;
 import org.junit.Rule;
 import org.junit.Test;
 
@@ -101,6 +107,28 @@ public class TestConfigMapper {
         assertEquals(12049.0, taskFromTask.getDuplicatedInDouble(), 0.00001);
     }
 
+    @Test
+    public void testValidation() {
+        // Here we do not attempt to test all of the JSR 303's validation rules.
+        // This is only to make sure the violation details will be propagated properly
+        // downstream to the caller side through TaskValidationException's message.
+        final ConfigMapper configMapper = ConfigMapperFactory.builder()
+                .addDefaultModules()
+                .withValidator(Validation.byProvider(ApacheValidationProvider.class)
+                        .configure()
+                        .buildValidatorFactory()
+                        .getValidator())
+                .build()
+                .createConfigMapper();
+        final org.embulk.config.ConfigSource maxCapViolatedConfig =
+                org.embulk.spi.Exec.newConfigSource().set("number", 101);
+
+        assertTrue("The exception has to at least contains the property name, the constraint and actual values.",
+                assertThrows(TaskValidationException.class,
+                        () -> configMapper.map(maxCapViolatedConfig, ToBeValidatedTask.class)
+                ).getMessage().matches("(?i).*number.*100.*101.*"));
+    }
+
     private static interface TypeFieldsTask extends Task {
         @Config("boolean")
         boolean getBoolean();
@@ -143,5 +171,9 @@ public class TestConfigMapper {
         public double getDuplicatedInDouble();
     }
 
-    // TODO: Add more tests with validation.
+    private interface ToBeValidatedTask extends Task {
+        @Config("number")
+        @Max(100)
+        Integer getNumber();
+    }
 }

--- a/src/main/java/org/embulk/util/config/TaskValidationException.java
+++ b/src/main/java/org/embulk/util/config/TaskValidationException.java
@@ -26,7 +26,21 @@ import org.embulk.config.ConfigException;
  */
 public class TaskValidationException extends ConfigException {
     <T> TaskValidationException(final Set<ConstraintViolation<T>> violations) {
-        super("Configuration violates constraints validated in task definition.",
-              new ConstraintViolationException(violations));
+        super(formatMessage(violations), new ConstraintViolationException(violations));
+    }
+
+    private static <T> String formatMessage(Set<ConstraintViolation<T>> violations) {
+        StringBuilder sb = new StringBuilder();
+        sb.append("Configuration violates constraints validated in task definition.");
+        for (ConstraintViolation<?> violation : violations) {
+            sb.append(" '");
+            sb.append(violation.getPropertyPath());
+            sb.append("' ");
+            sb.append(violation.getMessage());
+            sb.append(" but got ");
+            sb.append(violation.getInvalidValue());
+            sb.append('.');
+        }
+        return sb.toString();
     }
 }


### PR DESCRIPTION
Retains the old behavior from org.embulk.config.TaskValidationException that it encaptures the violation details in its message. There's a slight modification over the format: single quotes around the property name and violation messages are separated by periods.