### PR TITLE
Add creator methods for ConfigDiff, ConfigSource, TaskReport, and TaskSource, in 0.1.3-SNAPSHOT

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -6,7 +6,7 @@ plugins {
 }
 
 group = "org.embulk"
-version = "0.1.2-SNAPSHOT"
+version = "0.1.3-SNAPSHOT"
 description = "Embulk configuration processor for Embulk plugins"
 
 sourceCompatibility = 1.8
@@ -27,23 +27,23 @@ repositories {
 }
 
 dependencies {
-    compileOnly "org.embulk:embulk-api:0.10.12"
+    compileOnly "org.embulk:embulk-api:0.10.14"
     implementation "javax.validation:validation-api:1.1.0.Final"
     implementation "com.fasterxml.jackson.core:jackson-annotations:2.6.7"
     implementation "com.fasterxml.jackson.core:jackson-core:2.6.7"
     implementation "com.fasterxml.jackson.core:jackson-databind:2.6.7"
     implementation "com.fasterxml.jackson.datatype:jackson-datatype-jdk8:2.6.7"  // Required for java.util.Optional.
 
-    testImplementation "org.embulk:embulk-api:0.10.12"
+    testImplementation "org.embulk:embulk-api:0.10.14"
     testImplementation "org.apache.bval:bval-jsr303:0.5"
     testImplementation "org.junit.jupiter:junit-jupiter-api:5.6.1"
     testRuntimeOnly "org.junit.jupiter:junit-jupiter-engine:5.6.1"
 
     legacyTestImplementation "junit:junit:4.12"
-    legacyTestImplementation "org.embulk:embulk-core:0.10.12"
-    legacyTestImplementation "org.embulk:embulk-core:0.10.12:tests"
-    legacyTestImplementation "org.embulk:embulk-junit4:0.10.12"
-    legacyTestImplementation "org.embulk:embulk-deps:0.10.12"
+    legacyTestImplementation "org.embulk:embulk-core:0.10.14"
+    legacyTestImplementation "org.embulk:embulk-core:0.10.14:tests"
+    legacyTestImplementation "org.embulk:embulk-junit4:0.10.14"
+    legacyTestImplementation "org.embulk:embulk-deps:0.10.14"
     legacyTestImplementation "ch.qos.logback:logback-classic:1.1.3"
 }
 
@@ -82,7 +82,7 @@ javadoc {
         overview = "src/main/html/overview.html"
         links "https://docs.oracle.com/javase/8/docs/api/"
         links "https://docs.oracle.com/javaee/7/api/"
-        links "https://dev.embulk.org/embulk-api/0.10.12/javadoc/"
+        links "https://dev.embulk.org/embulk-api/0.10.14/javadoc/"
         links "https://fasterxml.github.io/jackson-core/javadoc/2.6/"
         links "https://fasterxml.github.io/jackson-databind/javadoc/2.6/"
         links "https://fasterxml.github.io/jackson-datatype-jdk8/javadoc/2.6/"

--- a/gradle/dependency-locks/compileClasspath.lockfile
+++ b/gradle/dependency-locks/compileClasspath.lockfile
@@ -6,5 +6,5 @@ com.fasterxml.jackson.core:jackson-core:2.6.7
 com.fasterxml.jackson.core:jackson-databind:2.6.7
 com.fasterxml.jackson.datatype:jackson-datatype-jdk8:2.6.7
 javax.validation:validation-api:1.1.0.Final
-org.embulk:embulk-api:0.10.12
+org.embulk:embulk-api:0.10.14
 org.msgpack:msgpack-core:0.8.11


### PR DESCRIPTION
`embulk-core`'s `Exec.new***` (e.g. `Exec.newConfigSource`) is sometimes used in Embulk plugins and their tests. Plugins with `embulk-util-config` still works with `Exec`'s, but nicer to have `embulk-util-config`'s own implementations.