### PR TITLE
Bump up to v0.2.0-SNAPSHOT

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -6,7 +6,7 @@ plugins {
 }
 
 group = "org.embulk"
-version = "0.1.5-SNAPSHOT"
+version = "0.2.0-SNAPSHOT"
 description = "Embulk configuration processor for Embulk plugins"
 
 sourceCompatibility = 1.8


### PR DESCRIPTION
#16 and #17 (already merged) are planned to be released as v0.1.5, but decided to skip for v0.2.0 as
* It turned out that `ZoneIdModule` needs a fix. (Will come soon.)
* More fixes are needed.
