### PR TITLE
Fix against IllegalAccessException: Class org.embulk.util.config.Compat can not access a member of class org.embulk.util.config.DataSourceImpl with modifiers "public"

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -79,6 +79,9 @@ javadoc {
     // "*NodeRebuilder" classes are unofficial and undocumented while ObjectNodeRebuilder is "public".
     exclude "org/embulk/util/config/rebuild/*.java"
 
+    // "DataSourceImpl" is unofficial and undocumented while it is "public".
+    exclude "org/embulk/util/config/DataSourceImpl.java"
+
     options {
         locale = "en_US"
         encoding = "UTF-8"

--- a/src/main/java/org/embulk/util/config/Compat.java
+++ b/src/main/java/org/embulk/util/config/Compat.java
@@ -25,6 +25,8 @@ import java.lang.reflect.Method;
 import java.util.Optional;
 import org.embulk.config.DataSource;
 import org.embulk.util.config.rebuild.ObjectNodeRebuilder;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 /**
  * Utility methods for compatibility before and after Embulk v0.10.2.
@@ -111,6 +113,8 @@ final class Compat {
             }
             throw new IllegalStateException("DataSource#toJson() threw unexpected Exception.", targetException);
         } catch (final IllegalAccessException ex) {
+            logger.debug("DataSource#toJson is not accessible unexpectedly. DataSource: {}, toJson: {}, ",
+                         source.getClass(), toJson);
             throw new IllegalStateException("DataSource#toJson() is not accessible.", ex);
         }
 
@@ -151,6 +155,8 @@ final class Compat {
             }
             throw new IllegalStateException("DataSourceImpl#getObjectNode() threw unexpected Exception.", targetException);
         } catch (final IllegalAccessException ex) {
+            logger.debug("DataSourceImpl#getObjectNode is not accessible unexpectedly. DataSourceImpl: {}, getObjectNode: {}, ",
+                         source.getClass(), getObjectNode);
             throw new IllegalStateException("DataSourceImpl#getObjectNode() is not accessible.", ex);
         }
 
@@ -192,4 +198,6 @@ final class Compat {
     }
 
     private static final ObjectMapper SIMPLE_MAPPER = new ObjectMapper();
+
+    private static final Logger logger = LoggerFactory.getLogger(Compat.class);
 }

--- a/src/main/java/org/embulk/util/config/Compat.java
+++ b/src/main/java/org/embulk/util/config/Compat.java
@@ -93,7 +93,7 @@ final class Compat {
     }
 
     private static Optional<String> callToJsonIfAvailable(final DataSource source) {
-        final Method toJson = getToJsonMethod(source.getClass());
+        final Method toJson = getToJsonMethod();
         if (toJson == null) {
             return Optional.empty();
         }
@@ -157,9 +157,20 @@ final class Compat {
         return ObjectNodeRebuilder.rebuild(coreObjectNode, mapper);
     }
 
-    private static Method getToJsonMethod(final Class<? extends DataSource> coreDataSourceImplClass) {
+    private static Method getToJsonMethod() {
         try {
-            return coreDataSourceImplClass.getMethod("toJson");
+            // Getting the "toJson" method from embulk-api's public interface "org.embulk.config.DataSource", not from an implementation class,
+            // for example "org.embulk.(util.)config.DataSourceImpl", so that invoking the method does not throw IllegalAccessException.
+            //
+            // If the method instance is retrieved from a non-public implementation class, invoking it can fail like:
+            //   java.lang.IllegalAccessException:
+            //   Class org.embulk.util.config.Compat can not access a member of class org.embulk.util.config.DataSourceImpl with modifiers "public"
+            //
+            // See also:
+            // https://stackoverflow.com/questions/25020756/java-lang-illegalaccessexception-can-not-access-a-member-of-class-java-util-col
+            //
+            // A method instance retrieved from the public interface "org.embulk.config.DataSource" would solve the problem.
+            return DataSource.class.getMethod("toJson");
         } catch (final NoSuchMethodException ex) {
             // Expected: toJson is not defined in Embulk v0.10.2 or earlier.
             return null;
@@ -168,9 +179,14 @@ final class Compat {
 
     private static Method getGetObjectNodeMethod(final Class<? extends DataSource> coreDataSourceImplClass) {
         try {
+            // Unlike "toJson" above, "getObjectNode" needs to be invoked only for org.embulk.config.DataSourceImpl
+            // because "getObjectNode" is removed from embulk-api's official "org.embul.config.DataSource", and
+            // implemented only in embulk-core's internal "org.embulk.config.DataSourceImpl".
+            //
+            // "org.embulk.config.DataSourceImpl" and its "getObjectNode" have been public.
             return coreDataSourceImplClass.getMethod("getObjectNode");
         } catch (final NoSuchMethodException ex) {
-            // Expected; getObjectNode may be implemented only in org.embulk.config.DataSourceImpl of earlier Embulk.
+            // Expected: getObjectNode may be implemented only in org.embulk.config.DataSourceImpl of earlier Embulk.
             return null;
         }
     }

--- a/src/main/java/org/embulk/util/config/DataSourceImpl.java
+++ b/src/main/java/org/embulk/util/config/DataSourceImpl.java
@@ -37,8 +37,10 @@ import org.embulk.config.TaskSource;
 /**
  * An implementation of {@code org.embulk.config.DataSource} for instances created mainly from {@link Task#dump()} and
  * {@link Task#toTaskSource()}.
+ *
+ * <p>It is {@code public} so that a reflection access to this class does not cause any error.
  */
-final class DataSourceImpl implements ConfigSource, TaskSource, TaskReport, ConfigDiff {
+public final class DataSourceImpl implements ConfigSource, TaskSource, TaskReport, ConfigDiff {
     DataSourceImpl(final ObjectNode data, final ObjectMapper objectMapper) {
         this.data = data;
         this.objectMapper = objectMapper;

--- a/src/test/java/org/embulk/util/config/TestCompat.java
+++ b/src/test/java/org/embulk/util/config/TestCompat.java
@@ -1,0 +1,36 @@
+/*
+ * Copyright 2020 The Embulk project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.embulk.util.config;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.node.ObjectNode;
+import java.io.IOException;
+import org.junit.jupiter.api.Test;
+
+public class TestCompat {
+    @Test
+    public void testToJson() throws IOException {
+        final ObjectNode node = SIMPLE_MAPPER.createObjectNode();
+        node.put("foo", "bar");
+        final DataSourceImpl impl = new DataSourceImpl(node, SIMPLE_MAPPER);
+        assertEquals("{\"foo\":\"bar\"}", Compat.toJson(impl));
+    }
+
+    private static final ObjectMapper SIMPLE_MAPPER = new ObjectMapper();
+}


### PR DESCRIPTION
I saw `IllegalAccessException` when I was trying to externalize `embulk-standards` as separate plugins in: https://github.com/embulk/embulk/pull/1363

```
... (snip) ...
Caused by: java.lang.IllegalStateException: DataSource#toJson() is not accessible.
	at org.embulk.util.config.Compat.callToJsonIfAvailable(Compat.java:114)
	at org.embulk.util.config.Compat.rebuildObjectNode(Compat.java:71)
	at org.embulk.util.config.TaskMapper.map(TaskMapper.java:73)
	at org.embulk.standards.StdoutOutputPlugin.open(StdoutOutputPlugin.java:82)
	at org.embulk.exec.LocalExecutorPlugin$ScatterTransactionalPageOutput.openOutputs(LocalExecutorPlugin.java:402)
	at org.embulk.exec.LocalExecutorPlugin$ScatterExecutor.runInputTask(LocalExecutorPlugin.java:257)
	at org.embulk.exec.LocalExecutorPlugin$ScatterExecutor.access$100(LocalExecutorPlugin.java:195)
	at org.embulk.exec.LocalExecutorPlugin$ScatterExecutor$1.call(LocalExecutorPlugin.java:234)
	at org.embulk.exec.LocalExecutorPlugin$ScatterExecutor$1.call(LocalExecutorPlugin.java:231)
	at java.util.concurrent.FutureTask.run(FutureTask.java:266)
	at java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1149)
	at java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:624)
	at java.lang.Thread.run(Thread.java:748)
Caused by: java.lang.IllegalAccessException: Class org.embulk.util.config.Compat can not access a member of class org.embulk.util.config.DataSourceImpl with modifiers "public"
	at sun.reflect.Reflection.ensureMemberAccess(Reflection.java:102)
	at java.lang.reflect.AccessibleObject.slowCheckMemberAccess(AccessibleObject.java:296)
	at java.lang.reflect.AccessibleObject.checkAccess(AccessibleObject.java:288)
	at java.lang.reflect.Method.invoke(Method.java:491)
	at org.embulk.util.config.Compat.callToJsonIfAvailable(Compat.java:103)
	... 12 more
```

I observed this error when both an input and an output are using `embulk-util-config:0.1.4`. It seems happening when a config from an input (made by `embulk-util-config:0.1.4`) is passed to an output, and processed by `embulk-util-config:0.1.4`).

Not 100% confident yet, but the reason looks because `org.embulk.util.config.DataSourceImpl` is not `public`, then the method `toJson` cannot be called. See also:
https://stackoverflow.com/questions/25020756/java-lang-illegalaccessexception-can-not-access-a-member-of-class-java-util-col

So, in this PR, I'm making three actions:
* Make `org.embulk.util.config.DataSourceImpl` `public`, although undocumented in Javadoc intentionally.
* Look for the `toJson` method instance from the `public` `org.embulk.config.DataSource` interface, not `org.embulk.util.config.DataSourceImpl`.
* Log more with `debug` against `IllegalAccessException`.

It looks happening in a very limited situation -- just a simple test did not reproduce this. But I expect that it fixed the error case above.