### PR TITLE
Throw an Exception that has a more descriptive message when trying to invoke getObjectNode for non-embulk-core DataSourceImpl

### DIFF
--- a/src/main/java/org/embulk/util/config/Compat.java
+++ b/src/main/java/org/embulk/util/config/Compat.java
@@ -133,7 +133,10 @@ final class Compat {
     private static ObjectNode callGetObjectNodeAndRebuildIfAvailable(final DataSource source, final ObjectMapper mapper) {
         final Class<? extends DataSource> coreDataSourceImplClass = source.getClass();
         if (!coreDataSourceImplClass.getCanonicalName().equals("org.embulk.config.DataSourceImpl")) {
-            throw new ClassCastException("DataSource specified is not org.embulk.config.DataSourceImpl.");
+            throw new ClassCastException(
+                    "DataSource specified is not org.embulk.config.DataSourceImpl. "
+                        + "The DataSource instance is unexpected to implement getObjectNode(). "
+                        + "DataSource class: " + source.getClass());
         }
         final Method getObjectNode = getGetObjectNodeMethod(coreDataSourceImplClass);
         if (getObjectNode == null) {


### PR DESCRIPTION
The Exception message in the error case of #24 was not very descriptive. This pull-request is just to improve the message.