### PR TITLE
Improve Exception messages in mapping failures

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -6,7 +6,7 @@ plugins {
 }
 
 group = "org.embulk"
-version = "0.3.0-SNAPSHOT"
+version = "0.3.1-SNAPSHOT"
 description = "Embulk configuration processor for Embulk plugins"
 
 sourceCompatibility = 1.8

--- a/src/main/java/org/embulk/util/config/ConfigMapper.java
+++ b/src/main/java/org/embulk/util/config/ConfigMapper.java
@@ -16,9 +16,7 @@
 
 package org.embulk.util.config;
 
-import com.fasterxml.jackson.core.JsonParseException;
 import com.fasterxml.jackson.core.JsonProcessingException;
-import com.fasterxml.jackson.databind.JsonMappingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.node.ObjectNode;
 import java.io.IOException;
@@ -81,16 +79,12 @@ public final class ConfigMapper {
         final T value;
         try {
             value = this.objectMapper.readValue(objectNode.traverse(), taskType);
-        } catch (final JsonMappingException ex) {
-            throw new ConfigException("Failed to map a JSON value into some object.", ex);
-        } catch (final JsonParseException ex) {
-            throw new ConfigException("Unexpected failure in parsing ObjectNode rebuilt from org.embulk.config.ConfigSource.", ex);
         } catch (final JsonProcessingException ex) {
-            throw new ConfigException("Unexpected failure in processing ObjectNode rebuilt from org.embulk.config.ConfigSource.", ex);
+            throw new ConfigException(buildExceptionMessage(ex, taskType), ex);
         } catch (final IOException ex) {
-            throw new ConfigException("Unexpected I/O error in ObjectNode rebuilt from org.embulk.config.ConfigSource.", ex);
+            throw new ConfigException(buildExceptionMessage(ex, taskType), ex);
         } catch (final RuntimeException ex) {
-            throw new ConfigException("Unexpected failure in ObjectNode rebuilt from org.embulk.config.ConfigSource.", ex);
+            throw new ConfigException(buildExceptionMessage(ex, taskType), ex);
         }
 
         if (this.validator != null) {
@@ -101,6 +95,21 @@ public final class ConfigMapper {
         }
 
         return value;
+    }
+
+    private static String buildExceptionMessage(final Exception ex, final Class<?> taskType) {
+        final StringBuilder messageBuilder = new StringBuilder();
+        messageBuilder.append("Failed to map Embulk's ConfigSource to ");
+        messageBuilder.append(taskType.getName());
+
+        final String originalMessage = ex.getMessage();
+        if (originalMessage != null) {
+            messageBuilder.append(": ");
+            messageBuilder.append(originalMessage);
+        } else {
+            messageBuilder.append(".");
+        }
+        return messageBuilder.toString();
     }
 
     private final ObjectMapper objectMapper;

--- a/src/main/java/org/embulk/util/config/ConfigMapper.java
+++ b/src/main/java/org/embulk/util/config/ConfigMapper.java
@@ -16,7 +16,6 @@
 
 package org.embulk.util.config;
 
-import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.node.ObjectNode;
 import java.io.IOException;
@@ -79,11 +78,7 @@ public final class ConfigMapper {
         final T value;
         try {
             value = this.objectMapper.readValue(objectNode.traverse(), taskType);
-        } catch (final JsonProcessingException ex) {
-            throw new ConfigException(buildExceptionMessage(ex, taskType), ex);
-        } catch (final IOException ex) {
-            throw new ConfigException(buildExceptionMessage(ex, taskType), ex);
-        } catch (final RuntimeException ex) {
+        } catch (final IOException | RuntimeException ex) {
             throw new ConfigException(buildExceptionMessage(ex, taskType), ex);
         }
 
@@ -97,7 +92,7 @@ public final class ConfigMapper {
         return value;
     }
 
-    private static String buildExceptionMessage(final Exception ex, final Class<?> taskType) {
+    static String buildExceptionMessage(final Exception ex, final Class<?> taskType) {
         final StringBuilder messageBuilder = new StringBuilder();
         messageBuilder.append("Failed to map Embulk's ConfigSource to ");
         messageBuilder.append(taskType.getName());

--- a/src/test/java/org/embulk/util/config/TestConfigMapper.java
+++ b/src/test/java/org/embulk/util/config/TestConfigMapper.java
@@ -1,0 +1,33 @@
+/*
+ * Copyright 2021 The Embulk project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.embulk.util.config;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import org.junit.jupiter.api.Test;
+
+public class TestConfigMapper {
+    @Test
+    public void testBuildExceptionMessage() {
+        assertEquals(
+                "Failed to map Embulk's ConfigSource to org.embulk.util.config.TestConfigMapper: foobar",
+                ConfigMapper.buildExceptionMessage(new RuntimeException("foobar"), TestConfigMapper.class));
+        assertEquals(
+                "Failed to map Embulk's ConfigSource to org.embulk.util.config.TestConfigMapper.",
+                ConfigMapper.buildExceptionMessage(new RuntimeException(), TestConfigMapper.class));
+    }
+}


### PR DESCRIPTION
`embulk-util-config`'s Exception messages have been difficult to understand, even against a type of "expected" failures, such as :

```
org.embulk.config.ConfigException: Unexpected failure in ObjectNode rebuilt from org.embulk.config.ConfigSource.
	at org.embulk.util.config.ConfigMapper.map(ConfigMapper.java:93)
        ...
	at java.lang.Thread.run(Thread.java:748)
Caused by: java.lang.IllegalArgumentException: Field 'region' is required but not set.
 at [Source: N/A; line: -1, column: -1]
	at com.fasterxml.jackson.databind.ObjectMapper._convert(ObjectMapper.java:3459)
	at com.fasterxml.jackson.databind.ObjectMapper.convertValue(ObjectMapper.java:3400)
	at com.fasterxml.jackson.databind.ObjectMapper.convertValue(ObjectMapper.java:3388)
	at org.embulk.util.config.TaskObjectsRetriever.buildTaskBackingObjectsOnlyAvailableInJson(TaskObjectsRetriever.java:167)
	at org.embulk.util.config.TaskObjectsRetriever.buildTaskBackingObjects(TaskObjectsRetriever.java:104)
	at org.embulk.util.config.ConfigTaskDeserializer.deserialize(ConfigTaskDeserializer.java:42)
	at org.embulk.util.config.ConfigTaskDeserializer.deserialize(ConfigTaskDeserializer.java:28)
	at com.fasterxml.jackson.databind.ObjectMapper._readValue(ObjectMapper.java:3708)
	at com.fasterxml.jackson.databind.ObjectMapper.readValue(ObjectMapper.java:2005)
	at org.embulk.util.config.ConfigMapper.map(ConfigMapper.java:83)
	... 62 more
Caused by: com.fasterxml.jackson.databind.JsonMappingException: Field 'region' is required but not set.
 at [Source: N/A; line: -1, column: -1]
	at com.fasterxml.jackson.databind.JsonMappingException.from(JsonMappingException.java:148)
	at org.embulk.util.config.TaskObjectsRetriever.buildTaskBackingObjects(TaskObjectsRetriever.java:126)
	at org.embulk.util.config.ConfigTaskDeserializer.deserialize(ConfigTaskDeserializer.java:42)
	at org.embulk.util.config.ConfigTaskDeserializer.deserialize(ConfigTaskDeserializer.java:28)
```

The top-level `ConfigException` does not include child's Exception message, and it says "Unexpected failure".

This PR improves such Exception messages to :
* Include child's Exception message.
* Not to say "Unexpected failure".
