### PR TITLE
Have much more noisy testing logs

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -190,8 +190,13 @@ signing {
 test {
     useJUnitPlatform()
     testLogging {
-        outputs.upToDateWhen { false }
+        events "passed", "skipped", "failed", "standardOut", "standardError"
+        exceptionFormat = org.gradle.api.tasks.testing.logging.TestExceptionFormat.FULL
+        showCauses = true
+        showExceptions = true
+        showStackTraces = true
         showStandardStreams = true
+        outputs.upToDateWhen { false }
     }
     systemProperty "org.embulk.embulk_util_config.version", "${project.version}"
 }
@@ -201,8 +206,13 @@ task legacyTest(type: Test, description: "Tests compatible with legacy Embulk Da
     testClassesDirs = sourceSets.legacyTest.output.classesDirs
 
     testLogging {
-        outputs.upToDateWhen { false }
+        events "passed", "skipped", "failed", "standardOut", "standardError"
+        exceptionFormat = org.gradle.api.tasks.testing.logging.TestExceptionFormat.FULL
+        showCauses = true
+        showExceptions = true
+        showStackTraces = true
         showStandardStreams = true
+        outputs.upToDateWhen { false }
     }
 }
 


### PR DESCRIPTION
It was an old pull request, but missed for a long time. Just adding verbose logging options.