### PR TITLE
Use BOM to specify Jackson's version, with adding a new Gradle task `checkDependencies`

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -56,10 +56,11 @@ dependencies {
 
     // Dependencies should be "api" so that their scope would be "compile" in "pom.xml".
     api "javax.validation:validation-api:1.1.0.Final"
-    api "com.fasterxml.jackson.core:jackson-annotations:2.6.7"
-    api "com.fasterxml.jackson.core:jackson-core:2.6.7"
-    api "com.fasterxml.jackson.core:jackson-databind:2.6.7.5"
-    api "com.fasterxml.jackson.datatype:jackson-datatype-jdk8:2.6.7"  // Required for java.util.Optional.
+    api platform("com.fasterxml.jackson:jackson-bom:2.6.7.5")
+    api "com.fasterxml.jackson.core:jackson-annotations"
+    api "com.fasterxml.jackson.core:jackson-core"
+    api "com.fasterxml.jackson.core:jackson-databind"
+    api "com.fasterxml.jackson.datatype:jackson-datatype-jdk8"  // Required for java.util.Optional.
 
     testImplementation "org.junit.jupiter:junit-jupiter-api:5.9.2"
     testImplementation "org.junit.jupiter:junit-jupiter-params:5.9.2"
@@ -116,6 +117,19 @@ sourcesJar {
 javadocJar {
     metaInf {
         from rootProject.file("LICENSE")
+    }
+}
+
+// A safer and strict alternative to: "dependencies" (and "dependencies --write-locks")
+//
+// This task fails explicitly when the specified dependency is not available.
+// In contrast, "dependencies (--write-locks)" does not fail even when a part the dependencies are unavailable.
+//
+// https://docs.gradle.org/7.6.1/userguide/dependency_locking.html#generating_and_updating_dependency_locks
+task checkDependencies {
+    notCompatibleWithConfigurationCache("The task \"checkDependencies\" filters configurations at execution time.")
+    doLast {
+        configurations.findAll { it.canBeResolved }.each { it.resolve() }
     }
 }
 

--- a/gradle.lockfile
+++ b/gradle.lockfile
@@ -5,6 +5,7 @@ com.fasterxml.jackson.core:jackson-annotations:2.6.7=compileClasspath,runtimeCla
 com.fasterxml.jackson.core:jackson-core:2.6.7=compileClasspath,runtimeClasspath
 com.fasterxml.jackson.core:jackson-databind:2.6.7.5=compileClasspath,runtimeClasspath
 com.fasterxml.jackson.datatype:jackson-datatype-jdk8:2.6.7=compileClasspath,runtimeClasspath
+com.fasterxml.jackson:jackson-bom:2.6.7.5=compileClasspath,runtimeClasspath
 javax.validation:validation-api:1.1.0.Final=compileClasspath,runtimeClasspath
 org.embulk:embulk-spi:0.11=compileClasspath
 org.msgpack:msgpack-core:0.8.24=compileClasspath


### PR DESCRIPTION
Same with https://github.com/embulk/embulk-util-json/pull/23 for `embulk-util-config`.