### PR TITLE
Bump the depended Jackson version to 2.15.3

### DIFF
--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -9,9 +9,9 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        jacksonVersion: [ "2.6.7.5", "2.7.9", "2.8.11", "2.9.10", "2.10.5", "2.11.4", "2.12.7", "2.13.5", "2.14.3", "2.15.2" ]
+        jacksonVersion: [ "2.15.3" ]
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v4
     - name: Set up OpenJDK 8
       uses: actions/setup-java@v3
       with:

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -10,7 +10,7 @@ jobs:
       hash-master: ${{ steps.hash-master.outputs.hash-master }}
       hash-main: ${{ steps.hash-main.outputs.hash-main }}
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v4
       with:
         fetch-depth: 0
     - id: hash-master
@@ -30,7 +30,7 @@ jobs:
     if: needs.diff.outputs.hash-master != needs.diff.outputs.hash-main
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v4
       with:
         fetch-depth: 0
     - name: Checkout master

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -11,7 +11,7 @@ jobs:
     strategy:
       fail-fast: true
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v4
     - name: Set up OpenJDK 8
       uses: actions/setup-java@v3
       with:

--- a/build.gradle
+++ b/build.gradle
@@ -8,7 +8,7 @@ plugins {
 
 ext {
     if (!project.hasProperty("jacksonVersionForJacksonTest")) {
-        jacksonVersionForJacksonTest = "2.6.7.5"
+        jacksonVersionForJacksonTest = "2.15.3"
     }
 }
 
@@ -62,7 +62,7 @@ dependencies {
 
     // Dependencies should be "api" so that their scope would be "compile" in "pom.xml".
     api "javax.validation:validation-api:1.1.0.Final"
-    api platform("com.fasterxml.jackson:jackson-bom:2.6.7.5")
+    api platform("com.fasterxml.jackson:jackson-bom:2.15.3")
     api "com.fasterxml.jackson.core:jackson-annotations"
     api "com.fasterxml.jackson.core:jackson-core"
     api "com.fasterxml.jackson.core:jackson-databind"
@@ -186,7 +186,7 @@ publishing {
                 developers {
                     developer {
                         name = "Dai MIKURUBE"
-                        email = "dmikurube@treasure-data.com"
+                        email = "dmikurube@acm.org"
                     }
                 }
 

--- a/gradle.lockfile
+++ b/gradle.lockfile
@@ -1,11 +1,11 @@
 # This is a Gradle generated file for dependency locking.
 # Manual edits can break the build and are not advised.
 # This file is expected to be part of source control.
-com.fasterxml.jackson.core:jackson-annotations:2.6.7=compileClasspath,runtimeClasspath
-com.fasterxml.jackson.core:jackson-core:2.6.7=compileClasspath,runtimeClasspath
-com.fasterxml.jackson.core:jackson-databind:2.6.7.5=compileClasspath,runtimeClasspath
-com.fasterxml.jackson.datatype:jackson-datatype-jdk8:2.6.7=compileClasspath,runtimeClasspath
-com.fasterxml.jackson:jackson-bom:2.6.7.5=compileClasspath,runtimeClasspath
+com.fasterxml.jackson.core:jackson-annotations:2.15.3=compileClasspath,runtimeClasspath
+com.fasterxml.jackson.core:jackson-core:2.15.3=compileClasspath,runtimeClasspath
+com.fasterxml.jackson.core:jackson-databind:2.15.3=compileClasspath,runtimeClasspath
+com.fasterxml.jackson.datatype:jackson-datatype-jdk8:2.15.3=compileClasspath,runtimeClasspath
+com.fasterxml.jackson:jackson-bom:2.15.3=compileClasspath,runtimeClasspath
 javax.validation:validation-api:1.1.0.Final=compileClasspath,runtimeClasspath
 org.embulk:embulk-spi:0.11=compileClasspath
 org.msgpack:msgpack-core:0.8.24=compileClasspath

--- a/src/main/java/org/embulk/util/config/ConfigMapperFactory.java
+++ b/src/main/java/org/embulk/util/config/ConfigMapperFactory.java
@@ -330,7 +330,7 @@ public final class ConfigMapperFactory {
 
         final int minor = com.fasterxml.jackson.core.json.PackageVersion.VERSION.getMinorVersion();
         if (minor < 14 || (minor == 15 && com.fasterxml.jackson.core.json.PackageVersion.VERSION.getPatchLevel() <= 2)) {
-            throw new UnsupportedOperationException("embulk-util-config is not used with Jackson 2.15.3 or later.");
+            throw new UnsupportedOperationException("embulk-util-config is not used with Jackson (jackson-core) 2.15.3 or later.");
         }
     }
 
@@ -341,7 +341,7 @@ public final class ConfigMapperFactory {
 
         final int minor = com.fasterxml.jackson.databind.cfg.PackageVersion.VERSION.getMinorVersion();
         if (minor < 14 || (minor == 15 && com.fasterxml.jackson.databind.cfg.PackageVersion.VERSION.getPatchLevel() <= 2)) {
-            throw new UnsupportedOperationException("embulk-util-config is not used with Jackson 2.15.3 or later.");
+            throw new UnsupportedOperationException("embulk-util-config is not used with Jackson (jackson-databind) 2.15.3 or later.");
         }
     }
 
@@ -352,7 +352,7 @@ public final class ConfigMapperFactory {
 
         final int minor = com.fasterxml.jackson.datatype.jdk8.PackageVersion.VERSION.getMinorVersion();
         if (minor < 14 || (minor == 15 && com.fasterxml.jackson.datatype.jdk8.PackageVersion.VERSION.getPatchLevel() <= 2)) {
-            throw new UnsupportedOperationException("embulk-util-config is not used with Jackson 2.15.3 or later.");
+            throw new UnsupportedOperationException("embulk-util-config is not used with Jackson (jackson-datatype-jdk8) 2.15.3 or later.");
         }
     }
 

--- a/src/main/java/org/embulk/util/config/ConfigMapperFactory.java
+++ b/src/main/java/org/embulk/util/config/ConfigMapperFactory.java
@@ -137,6 +137,9 @@ public final class ConfigMapperFactory {
      * Creates a {@link Builder} to build {@link ConfigMapperFactory}.
      */
     public static Builder builder() {
+        assertJacksonCoreVersion();
+        assertJacksonDataBindVersion();
+        assertJacksonDataTypeJdk8Version();
         return new Builder();
     }
 
@@ -318,6 +321,39 @@ public final class ConfigMapperFactory {
         objectMapper.registerModule(new DataSourceModule(objectMapper));
 
         return objectMapper;
+    }
+
+    private static void assertJacksonCoreVersion() {
+        if (com.fasterxml.jackson.core.json.PackageVersion.VERSION.getMajorVersion() != 2) {
+            throw new UnsupportedOperationException("embulk-util-config is not used with Jackson 2.");
+        }
+
+        final int minor = com.fasterxml.jackson.core.json.PackageVersion.VERSION.getMinorVersion();
+        if (minor < 14 || (minor == 15 && com.fasterxml.jackson.core.json.PackageVersion.VERSION.getPatchLevel() <= 2)) {
+            throw new UnsupportedOperationException("embulk-util-config is not used with Jackson 2.15.3 or later.");
+        }
+    }
+
+    private static void assertJacksonDataBindVersion() {
+        if (com.fasterxml.jackson.databind.cfg.PackageVersion.VERSION.getMajorVersion() != 2) {
+            throw new UnsupportedOperationException("embulk-util-config is not used with Jackson 2.");
+        }
+
+        final int minor = com.fasterxml.jackson.databind.cfg.PackageVersion.VERSION.getMinorVersion();
+        if (minor < 14 || (minor == 15 && com.fasterxml.jackson.databind.cfg.PackageVersion.VERSION.getPatchLevel() <= 2)) {
+            throw new UnsupportedOperationException("embulk-util-config is not used with Jackson 2.15.3 or later.");
+        }
+    }
+
+    private static void assertJacksonDataTypeJdk8Version() {
+        if (com.fasterxml.jackson.datatype.jdk8.PackageVersion.VERSION.getMajorVersion() != 2) {
+            throw new UnsupportedOperationException("embulk-util-config is not used with Jackson 2.");
+        }
+
+        final int minor = com.fasterxml.jackson.datatype.jdk8.PackageVersion.VERSION.getMinorVersion();
+        if (minor < 14 || (minor == 15 && com.fasterxml.jackson.datatype.jdk8.PackageVersion.VERSION.getPatchLevel() <= 2)) {
+            throw new UnsupportedOperationException("embulk-util-config is not used with Jackson 2.15.3 or later.");
+        }
     }
 
     private static final Logger logger = LoggerFactory.getLogger(ConfigMapperFactory.class);


### PR DESCRIPTION
A fix in Jackson 2.15.3 is needed to enable this fix https://github.com/embulk/embulk-util-json/pull/33#issuecomment-1727651903

https://github.com/FasterXML/jackson-core/pull/1111

It's time to upgrade the depended Jackson to the latest!