### PR TITLE
Link to Jackson's Javadoc at javadoc.io

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -114,9 +114,9 @@ javadoc {
         links "https://docs.oracle.com/javase/8/docs/api/"
         links "https://docs.oracle.com/javaee/7/api/"
         links "https://dev.embulk.org/embulk-spi/0.11/javadoc/"
-        links "https://fasterxml.github.io/jackson-core/javadoc/2.6/"
-        links "https://fasterxml.github.io/jackson-databind/javadoc/2.6/"
-        links "https://fasterxml.github.io/jackson-datatype-jdk8/javadoc/2.6/"
+        links "https://javadoc.io/doc/com.fasterxml.jackson.core/jackson-core/2.15.3/"
+        links "https://javadoc.io/doc/com.fasterxml.jackson.core/jackson-databind/2.15.3/"
+        links "https://javadoc.io/doc/com.fasterxml.jackson.datatype/jackson-datatype-jdk8/2.15.3/"
     }
 }
 


### PR DESCRIPTION
Jackson's Javadoc was maintained at https://fasterxml.github.io/ by GitHub Pages until Jackson 2.14, but they stopped to maintain it in GitHub Pages, and they moved their Javadocs to javadoc.io.

See:
- https://github.com/FasterXML/jackson-core/tree/2.15/docs
- https://github.com/FasterXML/jackson-core/wiki