### PR TITLE
Start using Gradle's version catalog

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -6,12 +6,6 @@ plugins {
     id "checkstyle"
 }
 
-ext {
-    if (!project.hasProperty("jacksonVersionForJacksonTest")) {
-        jacksonVersionForJacksonTest = "2.15.3"
-    }
-}
-
 repositories {
     mavenCentral()
 }
@@ -57,45 +51,37 @@ sourceSets {
 }
 
 dependencies {
-    compileOnly "org.embulk:embulk-spi:0.11"
-    compileOnly "org.slf4j:slf4j-api:2.0.7"
+    compileOnly libs.embulk.spi
+    compileOnly libs.slf4j
 
     // Dependencies should be "api" so that their scope would be "compile" in "pom.xml".
-    api "javax.validation:validation-api:1.1.0.Final"
-    api platform("com.fasterxml.jackson:jackson-bom:2.15.3")
-    api "com.fasterxml.jackson.core:jackson-annotations"
-    api "com.fasterxml.jackson.core:jackson-core"
-    api "com.fasterxml.jackson.core:jackson-databind"
-    api "com.fasterxml.jackson.datatype:jackson-datatype-jdk8"  // Required for java.util.Optional.
+    api libs.validation
 
-    testImplementation "org.junit.jupiter:junit-jupiter-api:5.10.0"
-    testImplementation "org.junit.jupiter:junit-jupiter-params:5.10.0"
-    testRuntimeOnly "org.junit.jupiter:junit-jupiter-engine:5.10.0"
+    api platform(libs.jackson.bom)
+    api libs.bundles.jackson
 
-    testImplementation "org.embulk:embulk-spi:0.11"
+    testImplementation platform(libs.junit5.bom)
+    testImplementation libs.bundles.junit5.implementation
+    testRuntimeOnly libs.bundles.junit5.runtime
 
-    testImplementation "org.apache.bval:bval-jsr303:0.5"
-    testImplementation "joda-time:joda-time:2.9.2"
-    testImplementation "ch.qos.logback:logback-classic:1.3.6"
+    testImplementation libs.embulk.spi
 
-    testImplementation platform("com.fasterxml.jackson:jackson-bom:$jacksonVersionForJacksonTest")
-    testImplementation "com.fasterxml.jackson.core:jackson-annotations"
-    testImplementation "com.fasterxml.jackson.core:jackson-core"
-    testImplementation "com.fasterxml.jackson.core:jackson-databind"
-    testImplementation "com.fasterxml.jackson.datatype:jackson-datatype-jdk8"  // Required for java.util.Optional.
+    testImplementation libs.bval
+    testImplementation libs.joda
+    testImplementation libs.logback
 
-    legacyTestImplementation "junit:junit:4.13.2"
+    testImplementation platform(testLibs.jackson.bom)
+    testImplementation testLibs.bundles.jackson
 
-    legacyTestImplementation "org.embulk:embulk-core:0.11.1"
-    legacyTestImplementation "org.embulk:embulk-deps:0.11.1"
-    legacyTestImplementation "org.embulk:embulk-junit4:0.11.1"
-    legacyTestImplementation "ch.qos.logback:logback-classic:1.3.6"
+    legacyTestImplementation libs.junit4
 
-    legacyTestImplementation platform("com.fasterxml.jackson:jackson-bom:$jacksonVersionForJacksonTest")
-    legacyTestImplementation "com.fasterxml.jackson.core:jackson-annotations"
-    legacyTestImplementation "com.fasterxml.jackson.core:jackson-core"
-    legacyTestImplementation "com.fasterxml.jackson.core:jackson-databind"
-    legacyTestImplementation "com.fasterxml.jackson.datatype:jackson-datatype-jdk8"  // Required for java.util.Optional.
+    legacyTestImplementation libs.embulk.core
+    legacyTestImplementation libs.embulk.deps
+    legacyTestImplementation libs.embulk.junit4
+    legacyTestImplementation libs.logback
+
+    legacyTestImplementation platform(testLibs.jackson.bom)
+    legacyTestImplementation testLibs.bundles.jackson
 }
 
 javadoc {
@@ -113,10 +99,10 @@ javadoc {
         overview = "src/main/html/overview.html"
         links "https://docs.oracle.com/javase/8/docs/api/"
         links "https://docs.oracle.com/javaee/7/api/"
-        links "https://dev.embulk.org/embulk-spi/0.11/javadoc/"
-        links "https://javadoc.io/doc/com.fasterxml.jackson.core/jackson-core/2.15.3/"
-        links "https://javadoc.io/doc/com.fasterxml.jackson.core/jackson-databind/2.15.3/"
-        links "https://javadoc.io/doc/com.fasterxml.jackson.datatype/jackson-datatype-jdk8/2.15.3/"
+        links "https://dev.embulk.org/embulk-spi/${libs.versions.embulk.spi.get()}/javadoc/"
+        links "https://javadoc.io/doc/com.fasterxml.jackson.core/jackson-core/${libs.versions.jackson.get()}/"
+        links "https://javadoc.io/doc/com.fasterxml.jackson.core/jackson-databind/${libs.versions.jackson.get()}/"
+        links "https://javadoc.io/doc/com.fasterxml.jackson.datatype/jackson-datatype-jdk8/${libs.versions.jackson.get()}/"
     }
 }
 

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -1,0 +1,54 @@
+[versions]
+embulk-spi = "0.11"
+slf4j-api = "2.0.7"
+validation-api = "1.1.0.Final"
+
+# Jackson needs to be higher than 2.5.13.
+# It is to align with the restriction of embulk-util-json: https://github.com/embulk/embulk-util-json/pull/37
+jackson = { require = "2.15.3", prefer = "2.16.2" }
+
+junit4 = "4.13.2"
+junit5 = "5.10.0"
+embulk-core = "0.11.1"
+bval-jsr303 = "0.5"
+logback = "1.3.6"
+joda-time = "2.9.2"
+
+[libraries]
+embulk-spi = { group = "org.embulk", name = "embulk-spi", version.ref = "embulk-spi" }
+slf4j = { group = "org.slf4j", name = "slf4j-api", version.ref = "slf4j-api" }
+validation = { group = "javax.validation", name = "validation-api", version.ref = "validation-api" }
+jackson-bom = { group = "com.fasterxml.jackson", name = "jackson-bom", version.ref = "jackson" }
+jackson-annotations = { group = "com.fasterxml.jackson.core", name = "jackson-annotations" }
+jackson-core = { group = "com.fasterxml.jackson.core", name = "jackson-core" }
+jackson-databind = { group = "com.fasterxml.jackson.core", name = "jackson-databind" }
+jackson-datatype-jdk8 = { group = "com.fasterxml.jackson.datatype", name = "jackson-datatype-jdk8" }
+junit4 = { group = "junit", name = "junit", version.ref = "junit4" }
+junit5-bom = { group = "org.junit", name = "junit-bom", version.ref = "junit5" }
+junit5-api = { group = "org.junit.jupiter", name = "junit-jupiter-api" }
+junit5-params = { group = "org.junit.jupiter", name = "junit-jupiter-params" }
+junit5-engine = { group = "org.junit.jupiter", name = "junit-jupiter-engine" }
+embulk-core = { group = "org.embulk", name = "embulk-core", version.ref = "embulk-core" }
+embulk-deps = { group = "org.embulk", name = "embulk-deps", version.ref = "embulk-core" }
+embulk-junit4 = { group = "org.embulk", name = "embulk-junit4", version.ref = "embulk-core" }
+bval = { group = "org.apache.bval", name = "bval-jsr303", version.ref = "bval-jsr303" }
+logback = { group = "ch.qos.logback", name = "logback-classic", version.ref = "logback" }
+joda = { group = "joda-time", name = "joda-time", version.ref = "joda-time" }
+
+[bundles]
+
+jackson = [
+  "jackson-annotations",
+  "jackson-core",
+  "jackson-databind",
+  "jackson-datatype-jdk8",
+]
+
+junit5-implementation = [
+  "junit5-api",
+  "junit5-params",
+]
+
+junit5-runtime = [
+  "junit5-engine",
+]

--- a/settings-gradle.lockfile
+++ b/settings-gradle.lockfile
@@ -1,0 +1,4 @@
+# This is a Gradle generated file for dependency locking.
+# Manual edits can break the build and are not advised.
+# This file is expected to be part of source control.
+empty=incomingCatalogForLibs0

--- a/settings.gradle
+++ b/settings.gradle
@@ -1,1 +1,20 @@
 rootProject.name = "embulk-util-config"
+
+dependencyResolutionManagement {
+    versionCatalogs {
+        testLibs {
+            def jacksonVersion = version("jackson", providers.gradleProperty("jacksonVersionForJacksonTest").getOrElse("2.15.3"))
+
+            library("jackson-bom", "com.fasterxml.jackson", "jackson-bom").versionRef(jacksonVersion)
+
+            library("jackson-annotations", "com.fasterxml.jackson.core", "jackson-annotations").withoutVersion()
+            library("jackson-core", "com.fasterxml.jackson.core", "jackson-core").withoutVersion()
+            library("jackson-databind", "com.fasterxml.jackson.core", "jackson-databind").withoutVersion()
+
+            // Required for java.util.Optional.
+            library("jackson-datatype-jdk8", "com.fasterxml.jackson.datatype", "jackson-datatype-jdk8").withoutVersion()
+
+            bundle("jackson", [ "jackson-annotations", "jackson-core", "jackson-databind", "jackson-datatype-jdk8" ])
+        }
+    }
+}


### PR DESCRIPTION
It starts using Gradle's "version catalog" to manage dependency library versions by a static TOML file. It would allow dependabot to be more useful.

https://docs.gradle.org/8.7/userguide/platforms.html#sub:conventional-dependencies-toml

At the same time, it updates the Javadoc links based on the version catalog.