### PR TITLE
Implement Compat.toMap to retrieve a Map object from DataSource

### DIFF
--- a/src/main/java/org/embulk/util/config/DataSourceImpl.java
+++ b/src/main/java/org/embulk/util/config/DataSourceImpl.java
@@ -454,7 +454,8 @@ public final class DataSourceImpl implements ConfigSource, TaskSource, TaskRepor
         }
     }
 
-    private static Map<String, Object> nodeToMap(final ObjectNode object) {
+    // Not private for Compat.toMap.
+    static Map<String, Object> nodeToMap(final ObjectNode object) {
         final LinkedHashMap<String, Object> map = new LinkedHashMap<>();
         for (final Map.Entry<String, JsonNode> field : (Iterable<Map.Entry<String, JsonNode>>) () -> object.fields()) {
             map.put(field.getKey(), nodeToJavaObject(field.getValue()));

--- a/src/test/java/org/embulk/util/config/TestCompat.java
+++ b/src/test/java/org/embulk/util/config/TestCompat.java
@@ -21,6 +21,7 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.node.ObjectNode;
 import java.io.IOException;
+import java.util.LinkedHashMap;
 import org.junit.jupiter.api.Test;
 
 public class TestCompat {
@@ -30,6 +31,17 @@ public class TestCompat {
         node.put("foo", "bar");
         final DataSourceImpl impl = new DataSourceImpl(node, SIMPLE_MAPPER);
         assertEquals("{\"foo\":\"bar\"}", Compat.toJson(impl));
+    }
+
+    @Test
+    public void testToMap() throws IOException {
+        final ObjectNode node = SIMPLE_MAPPER.createObjectNode();
+        node.put("foo", "bar");
+        final DataSourceImpl impl = new DataSourceImpl(node, SIMPLE_MAPPER);
+
+        final LinkedHashMap<String, Object> expected = new LinkedHashMap<>();
+        expected.put("foo", "bar");
+        assertEquals(expected, Compat.toMap(impl));
     }
 
     private static final ObjectMapper SIMPLE_MAPPER = new ObjectMapper();


### PR DESCRIPTION
Embulk's SPI has had `DataSource#toMap`, in addition to `DataSource#toJson`, since v0.10.41. https://github.com/embulk/embulk/pull/1534

However, it has not been used from `embulk-util-config` so far yet. This pull request is the first step to start using `toMap`.

Constructing local `ConfigSource` from `Map` should be more efficient than from a stringified JSON.